### PR TITLE
Stop using NDNts Endpoint class

### DIFF
--- a/snippets/communication/consumer.ts
+++ b/snippets/communication/consumer.ts
@@ -1,6 +1,6 @@
 import { Interest } from '@ndn/packet';
 import { WsTransport } from '@ndn/ws-transport';
-import { Endpoint } from '@ndn/endpoint';
+import { consume } from '@ndn/endpoint';
 
 // Code running in the browser cannot connect to a local Unix socket.
 // In this example, we connect to a remote NFD instance, running as
@@ -8,15 +8,12 @@ import { Endpoint } from '@ndn/endpoint';
 const uplink = await WsTransport.createFace({}, "wss://suns.cs.ucla.edu/ws/");
 console.log(`Connected to NFD at ${uplink.remoteAddress}`);
 
-// Construct an Endpoint on the default forwarder instance.
-const endpoint = new Endpoint();
-
 // Create an Interest packet
 const interest = new Interest(`/ndn/edu/arizona/ping/NDNts/${Date.now()}`);
 
 // Send the Interest packet and wait for the Data packet
 try {
-    const data = await endpoint.consume(interest);
+    const data = await consume(interest);
     console.log(`Received data with name [${data.name}]`);
 } catch (err: any) {
     console.warn(err);

--- a/snippets/communication/producer.ts
+++ b/snippets/communication/producer.ts
@@ -1,6 +1,6 @@
 import { Data, digestSigning } from '@ndn/packet';
 import { WsTransport } from '@ndn/ws-transport';
-import { Endpoint } from '@ndn/endpoint';
+import { produce } from '@ndn/endpoint';
 import { toUtf8 } from '@ndn/util';
 
 // Code running in the browser cannot connect to a local Unix socket.
@@ -9,11 +9,8 @@ import { toUtf8 } from '@ndn/util';
 const uplink = await WsTransport.createFace({}, "wss://suns.cs.ucla.edu/ws/");
 console.log(`Connected to NFD at ${uplink.remoteAddress}`);
 
-// Construct an Endpoint on the default forwarder instance.
-const endpoint = new Endpoint();
-
 // Start one producer
-const myProducer = endpoint.produce('/edu/ucla/cs/118/notes', async (interest) => {
+const myProducer = produce('/edu/ucla/cs/118/notes', async (interest) => {
     console.log(`Received Interest packet for ${interest.name.toString()}`);
     // Create the content bytes for the Data packet
     const content = toUtf8("Hello, NDN!");

--- a/snippets/security/trust-domain.ts
+++ b/snippets/security/trust-domain.ts
@@ -1,7 +1,7 @@
-import { Component, Data, Name } from '@ndn/packet';
+import { Component, Data, Name, ValidityPeriod } from '@ndn/packet';
 import { Encoder } from '@ndn/tlv';
 import { toHex, toUtf8 } from '@ndn/util';
-import { Certificate, Ed25519, generateSigningKey, ValidityPeriod } from '@ndn/keychain';
+import { Certificate, Ed25519, generateSigningKey } from '@ndn/keychain';
 
 // Generate trust anchor of admin
 const adminIdentityName = new Name('/lab/admin');

--- a/snippets/testbed/app-consumer.ts
+++ b/snippets/testbed/app-consumer.ts
@@ -1,16 +1,13 @@
 import { connectToNetwork } from "@ndn/autoconfig";
-import { Endpoint } from "@ndn/endpoint";
+import { consume } from "@ndn/endpoint";
 import { Interest } from "@ndn/packet";
 
-// Connect the default forwarder instance to the closest NDN testbed node using the FCH secvice
+// Connect the default forwarder instance to the closest NDN testbed node using the FCH service
 await connectToNetwork({
     fallback: ["titan.cs.memphis.edu"],  // optional fallback list
     connectTimeout: 3000,                // optional connection timeout
 });
 
-// Create an endpoint using the default forwarder instance
-const endpoint = new Endpoint();
-
 // Send an Interest to a ping server on the testbed
 const interest = new Interest(`/ndn/edu/memphis/ping/1234`);
-const data = await endpoint.consume(interest); // wait for echo
+const data = await consume(interest); // wait for echo


### PR DESCRIPTION
Endpoint class has been deleted in favor of standalone functions in @ndn/endpoint package.

Also, import ValidityPeriod from @ndn/packet.